### PR TITLE
format timestamp

### DIFF
--- a/src/components/EndpointHistory.vue
+++ b/src/components/EndpointHistory.vue
@@ -19,6 +19,9 @@ export default {
       while (tmp.length < 20) {
         tmp.unshift({});
       }
+      for (let t of tmp) {
+        t.timestamp = new Date(t.timestamp).toLocaleString();
+      }
       return tmp;
     }
   }


### PR DESCRIPTION
Format the timestamp to a human-readable format. The `.toLocaleString()` function takes care of localization in the browser.